### PR TITLE
bird2: bump to version 2.13

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.12
+PKG_VERSION:=2.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=3ec462a237d06d1f4455d6ec00a42f0b1686061fc988e5c89a841d01dd753b53
+PKG_HASH:=8d895e3e311880e9efb888b4386cbec2f7e18bfb8334e8d4c8ca7c4341092638
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Signed-off-by: Bradford Zhang <zyc@zyc.name>
(cherry picked from commit 6410411b123d57a07546c0cb056dca86e94e10dc)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
